### PR TITLE
Change update_site_id() API to use /users/current

### DIFF
--- a/custom_components/omada/api/controller.py
+++ b/custom_components/omada/api/controller.py
@@ -82,14 +82,15 @@ class Controller:
 
         response = await self._controller_request(
             "get",
-            "/sites",
+            "/users/current",
             params=[("currentPage", "1"), ("currentPageSize", "10000")],
             private=True,
         )
 
-        for site in response["data"]:
+        LOGGER.debug("current user %s", response)
+        for site in response["privilege"]["sites"]:
             if site["name"] == self.site:
-                self._site_id = site["id"]
+                self._site_id = site["key"]
                 break
 
         if not self._site_id:


### PR DESCRIPTION
After update to v5 (software controller using docker), the integration failed (cannot access with service like  #16) .  So I enable debug and some logging, it seems the access to /sites API failed with  (Forbidden) error  From the thread https://github.com/ghaberek/omada-api/issues/3 It seems /users/current can also access the site information (and that works for me)  
