### PR TITLE
Add connected clients sensor

### DIFF
--- a/custom_components/omada/api/api.py
+++ b/custom_components/omada/api/api.py
@@ -86,3 +86,6 @@ class APIItems:
 
     def __iter__(self):
         return self.items.__iter__()
+
+    def __len__(self):
+        return self.items.__len__()

--- a/custom_components/omada/api/clients.py
+++ b/custom_components/omada/api/clients.py
@@ -25,6 +25,10 @@ class Clients(APIItems):
     def __init__(self, request):
         super().__init__(request, END_POINT, "mac", Client, data_key="data")
 
+    @property
+    def connected_clients(self) -> "list[Client]":
+        return [item for item in self.items.values()]
+
 
 class Client(APIItem):
     """Defines all the properties for a Client"""

--- a/custom_components/omada/api/clients.py
+++ b/custom_components/omada/api/clients.py
@@ -25,10 +25,6 @@ class Clients(APIItems):
     def __init__(self, request):
         super().__init__(request, END_POINT, "mac", Client, data_key="data")
 
-    @property
-    def connected_clients(self) -> "list[Client]":
-        return [item for item in self.items.values()]
-
 
 class Client(APIItem):
     """Defines all the properties for a Client"""

--- a/custom_components/omada/sensor.py
+++ b/custom_components/omada/sensor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ipaddress
 import logging
 
 from collections.abc import Callable
@@ -64,7 +65,8 @@ def controller_connected_clients_extra_attributes_fn(controller: OmadaController
     if controller.api.clients:
         # Convert list of clients to list of dicts with minimal attributes
         client_keys = ["mac", "name", "ip"]
-        attributes["clients"] = [{k: d[k] for k in d if k in client_keys} for d in [c._raw for c in controller.api.clients.connected_clients]]
+        clients = [{k: d[k] for k in d if k in client_keys} for d in [c._raw for c in controller.api.clients.connected_clients]]
+        attributes["clients"] = sorted(clients, key=lambda x: ipaddress.IPv4Address(x["ip"]))
     return attributes
 
 


### PR DESCRIPTION
Add a connected clients sensor that contains the total number of connected clients.
It also includes the list of clients (mac, name, ip) in the `clients` attribute of the sensor.
Example:
![image](https://github.com/zachcheatham/ha-omada/assets/1945295/637dd121-7c9d-4e02-bbeb-b5d6cf8e81ea)


