### PR TITLE
Fix client extra attributes

### DIFF
--- a/custom_components/omada/sensor.py
+++ b/custom_components/omada/sensor.py
@@ -68,7 +68,7 @@ def controller_clients_extra_attributes_fn(controller: OmadaController) -> Mappi
     if controller.api.clients:
         # Convert list of clients to list of dicts with minimal attributes
         clients = [{"mac": c.mac, "name": c.name, "ip": c.ip} for c in controller.api.clients.items.values()]
-        attributes["clients"] = sorted(clients, key=lambda x: ipaddress.IPv4Address(x["ip"]))
+        attributes["clients"] = sorted(clients, key=lambda x: ipaddress.ip_address(x["ip"] if x["ip"] else "0.0.0.0"))
     return attributes
 
 


### PR DESCRIPTION
This should fix https://github.com/zachcheatham/ha-omada/issues/111 by using a default ip 0.0.0.0 if no ip is found (or None) for a client.