### PR TITLE
Use async on timeout and convert to asyncio.timeout

### DIFF
--- a/custom_components/omada/api/controller.py
+++ b/custom_components/omada/api/controller.py
@@ -1,5 +1,5 @@
 import logging
-import async_timeout
+import asyncio
 
 from dataclasses import dataclass
 from asyncio.exceptions import TimeoutError
@@ -206,7 +206,7 @@ class Controller:
         LOGGER.debug("Requesting: %s - Params: %s - JSON: %s - Headers %s", url, params, json, headers)
 
         try:
-            with async_timeout.timeout(self._req_timeout):
+            async with asyncio.timeout(self._req_timeout):
                 async with self._session.request(
                         method,
                         url,


### PR DESCRIPTION
The integration wouldn't start with error:

```
nov 07 13:37:05 hass1 hass[1247001]: 2024-11-07 13:37:05.747 ERROR (MainThread) [homeassistant.config_entries] Error setting up entry Omada Controller default: default for omada
nov 07 13:37:05 hass1 hass[1247001]: Traceback (most recent call last):
nov 07 13:37:05 hass1 hass[1247001]:   File "/opt/homeassistant-3.12/lib/python3.12/site-packages/homeassistant/config_entries.py", line 594, in async_setup
nov 07 13:37:05 hass1 hass[1247001]:     result = await component.async_setup_entry(hass, self)
nov 07 13:37:05 hass1 hass[1247001]:              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
nov 07 13:37:05 hass1 hass[1247001]:   File "/var/local/homeassistant/.homeassistant/custom_components/omada/__init__.py", line 32, in async_setup_entry
nov 07 13:37:05 hass1 hass[1247001]:     await omada_controller.async_setup()
nov 07 13:37:05 hass1 hass[1247001]:   File "/var/local/homeassistant/.homeassistant/custom_components/omada/controller.py", line 117, in async_setup
nov 07 13:37:05 hass1 hass[1247001]:     self.api = await get_api_controller(
nov 07 13:37:05 hass1 hass[1247001]:                ^^^^^^^^^^^^^^^^^^^^^^^^^
nov 07 13:37:05 hass1 hass[1247001]:   File "/var/local/homeassistant/.homeassistant/custom_components/omada/controller.py", line 290, in get_api_controller
nov 07 13:37:05 hass1 hass[1247001]:     await controller.login()
nov 07 13:37:05 hass1 hass[1247001]:   File "/var/local/homeassistant/.homeassistant/custom_components/omada/api/controller.py", line 58, in login
nov 07 13:37:05 hass1 hass[1247001]:     await self._update_api_info()
nov 07 13:37:05 hass1 hass[1247001]:   File "/var/local/homeassistant/.homeassistant/custom_components/omada/api/controller.py", line 74, in _update_api_info
nov 07 13:37:05 hass1 hass[1247001]:     response = await self._request("get", f"{self.url}/api/info")
nov 07 13:37:05 hass1 hass[1247001]:                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
nov 07 13:37:05 hass1 hass[1247001]:   File "/var/local/homeassistant/.homeassistant/custom_components/omada/api/controller.py", line 207, in _request
nov 07 13:37:05 hass1 hass[1247001]:     with asyncio.timeout(30):
nov 07 13:37:05 hass1 hass[1247001]:          ^^^^^^^^^^^^^^^^^^^
nov 07 13:37:05 hass1 hass[1247001]: TypeError: 'Timeout' object does not support the context manager protocol
```

Solely converting the deprecated `asyncio_timeout` to `asyncio.timoeut` was not sufficient. Wrapping the timeout in `async` did the trick.