### PR TITLE
Support wired clients & add new WiFi standards

### DIFF
--- a/custom_components/omada/api/clients.py
+++ b/custom_components/omada/api/clients.py
@@ -3,6 +3,7 @@ from .api import (APIItems, APIItem)
 END_POINT = "/clients"
 
 WIFI_MODE = [
+    "Unknown",
     "11a",
     "11b",
     "11g",

--- a/custom_components/omada/api/clients.py
+++ b/custom_components/omada/api/clients.py
@@ -75,7 +75,8 @@ class Client(APIItem):
 
     @property
     def wifi_mode(self) -> str:
-        return WIFI_MODE[self._raw.get("wifiMode", 0)]
+        mode = self._raw.get("wifiMode", 0)
+        return WIFI_MODE[mode] if 0 <= mode < len(WIFI_MODE) else "Unknown"
 
     @property
     def ap_name(self) -> str | None:

--- a/custom_components/omada/api/clients.py
+++ b/custom_components/omada/api/clients.py
@@ -3,7 +3,6 @@ from .api import (APIItems, APIItem)
 END_POINT = "/clients"
 
 WIFI_MODE = [
-    "Unknown",
     "11a",
     "11b",
     "11g",
@@ -11,7 +10,9 @@ WIFI_MODE = [
     "11ng",
     "11ac",
     "11axa",
-    "11axg"
+    "11axg",
+    "11beg",
+    "11bea"
 ]
 
 RADIO = [

--- a/custom_components/omada/api/clients.py
+++ b/custom_components/omada/api/clients.py
@@ -22,6 +22,9 @@ RADIO = [
     "6ghz"
 ]
 
+CONNECT_TYPE_WIRELESS_GUEST = 0
+CONNECT_TYPE_WIRELESS_USER = 1
+CONNECT_TYPE_WIRED_USER = 2
 
 class Clients(APIItems):
     def __init__(self, request):

--- a/custom_components/omada/device_tracker.py
+++ b/custom_components/omada/device_tracker.py
@@ -48,7 +48,13 @@ CONNECTED_WIRED_CLIENT_ATTRIBUTES = (
     "ip",
     "mac",
     "wireless",
-    "guest"
+    "guest",
+    "switch_port",
+    "switch_mac",
+    "switch_name",
+    "standard_port",
+    "vlan_id",
+    "network_name"
 )
 
 DISCONNECTED_CLIENT_ATTRIBUTES = (


### PR DESCRIPTION
Hi maintainers.

This PR addresses **Issue #13 - Add device tracker for wired connections**

I stumbled upon this project while considering writing my own Omada HASS integration. I can see a ton of work has gone into it. Thank you for your work to keep something like this going.

I run a heavily wired home network, so I wanted to add device tracker, etc support for wired clients.

I'm not an experienced HASS developer, and not a Python thought leader by any means; I've tried to keep my changes simple and thrown in a couple of things I would usually do, but welcome any feedback about keeping to any standards you might have.

Notes:

- [x] Added device tracker support for wired clients, by improving the logic that detects if a client is allowed or not
- [x] Added additional HASS entity attributes to wired clients for things like VLAN ID and switch name/port [1]
- [x] Added optional debug logging to `is_allowed_client` to see how the filter is working without needing to crack open the code [2]
- [x] Added the latest WiFi 7 standards into the enum list (was able to test this ok on my EAP772 AP + iPhone 16 Pro) [3]
- [x] Also added a safeguard to avoid future exceptions if newer WiFi standards are added (I initially detected this thanks to my WiFi 7 AP + iPhone 16 Pro 😂) - it labels it as "Unknown" if the standard isn't in the list, rather than throwing an exception.

[1]
<img width="469" alt="image" src="https://github.com/user-attachments/assets/57e8489b-96ba-4b21-b2df-8ff9ec591358" />

[2]
<img width="216" alt="image" src="https://github.com/user-attachments/assets/5de981be-b160-4c20-8a50-b79884493c7c" />

[3]
<img width="477" alt="image" src="https://github.com/user-attachments/assets/bffdc2de-4d8e-4d2e-bee4-f8c7fa4cf5e8" />
