### PR TITLE
Add button to reboot a device

### DIFF
--- a/custom_components/omada/api/devices.py
+++ b/custom_components/omada/api/devices.py
@@ -272,6 +272,9 @@ class Devices(APIItems):
 
         await self._request("PATCH", f"/eaps/{mac}", json={"wlanId": wlan_id, "ssidOverrides": existing_overrides})
 
+    async def trigger_reboot(self, mac: str) -> None:
+        await self._request("POST", f"/cmd/devices/{mac}/reboot", json={"mac": mac})
+
     async def trigger_update(self, mac: str) -> None:
         await self._request("POST", f"/cmd/devices/{mac}/onlineUpgrade", json={"mac": mac})
 

--- a/custom_components/omada/button.py
+++ b/custom_components/omada/button.py
@@ -18,7 +18,7 @@ from .controller import OmadaController
 from .api.controller import Controller
 
 from .const import DOMAIN as OMADA_DOMAIN
-from .omada_entity import (OmadaEntity, OmadaEntityDescription, client_device_info_fn, unique_id_fn)
+from .omada_entity import (OmadaEntity, OmadaEntityDescription, device_device_info_fn, client_device_info_fn, unique_id_fn)
 
 from .omada_controller_entity import (
     OmadaControllerEntity,
@@ -28,6 +28,7 @@ from .omada_controller_entity import (
 )
 
 AI_OPTIMIZATION_BUTTON = "ai_optimization"
+REBOOT_BUTTON = "reboot"
 RECONNECT_BUTTON = "reconnect"
 
 LOGGER = logging.getLogger(__name__)
@@ -35,6 +36,10 @@ LOGGER = logging.getLogger(__name__)
 @callback
 async def start_rf_planning_fn(api: Controller) -> None:
     await api.start_rf_planning()
+
+@callback
+async def reboot_device_fn(api: Controller, mac: str) -> None:
+    await api.devices.trigger_reboot(mac)
 
 @callback
 async def reconnect_client_fn(api: Controller, mac: str) -> None:
@@ -54,6 +59,19 @@ class OmadaButtonEntityDescription(
 ):
     """Omada Button Entity Description"""
 
+
+@dataclass
+class OmadaDeviceButtonEntityDescriptionMixin:
+    activate_fn: Callable[[OmadaController], None]
+
+
+@dataclass
+class OmadaDeviceButtonEntityDescription(
+    ButtonEntityDescription,
+    OmadaEntityDescription,
+    OmadaDeviceButtonEntityDescriptionMixin,
+):
+    """Omada Device Button Entity Description"""
 
 @dataclass
 class OmadaControllerButtonEntityDescriptionMixin:
@@ -85,6 +103,25 @@ CONTROLLER_ENTITY_DESCRIPTIONS: dict[
         name_fn=lambda *_: "Start WLAN Optimization",
         unique_id_fn=controller_unique_id_fn,
         activate_fn=start_rf_planning_fn
+    )
+}
+
+DEVICE_ENTITY_DESCRIPTIONS: dict[
+    str, OmadaDeviceButtonEntityDescription
+] = {
+    REBOOT_BUTTON: OmadaDeviceButtonEntityDescription(
+        domain=DOMAIN,
+        key=REBOOT_BUTTON,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        has_entity_name=True,
+        icon="mdi:restart",
+        allowed_fn=lambda controller, mac: controller.option_track_devices,
+        supported_fn=lambda controller, mac: True,
+        available_fn=lambda controller, mac: controller.available,
+        device_info_fn=device_device_info_fn,
+        name_fn=lambda *_: "Reboot",
+        unique_id_fn=unique_id_fn,
+        activate_fn=reboot_device_fn
     )
 }
 
@@ -122,6 +159,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 OmadaButtonEntity,
                 CLIENT_ENTITY_DESCRIPTIONS,
                 async_add_entities)
+        if controller.option_track_devices:
+            controller.register_platform_entities(
+                controller.api.devices,
+                OmadaDeviceButtonEntity,
+                DEVICE_ENTITY_DESCRIPTIONS,
+                async_add_entities)
 
     for signal in (controller.signal_update, controller.signal_options_update):
         config_entry.async_on_unload(
@@ -147,6 +190,20 @@ class OmadaButtonEntity(OmadaEntity, ButtonEntity):
     entity_description: OmadaControllerButtonEntityDescription
 
     def __init__(self, mac: str, controller: OmadaController, description: OmadaEntityDescription) -> None:
+        super().__init__(mac, controller, description)
+
+    async def async_press(self) -> None:
+        await self.entity_description.activate_fn(self.controller.api, self._mac)
+
+
+class OmadaDeviceButtonEntity(OmadaEntity, ButtonEntity):
+
+    entity_description: OmadaControllerButtonEntityDescription
+
+    def __init__(
+            self, mac: str, controller: OmadaController, description: OmadaDeviceEntityDescription
+    ) -> None:
+
         super().__init__(mac, controller, description)
 
     async def async_press(self) -> None:


### PR DESCRIPTION
Added buttons to reboot each device.

Rationale: I have two access points that at some random point during the day stop working on the 2.4Ghz band. The only indication that something is wrong is a temporary increase in cpu and memory usage and then all devices dropping from the network. I am so fed up with these devices tbh (2x EAP650), worst buy ever. Anyway, I was hoping to create an automation in HA to just reboot the devices when this happens.

The buttons are working for my two EAP650 devices. I am not sure if other device types can also be rebooted this way. The api seems to suggest that it should work. I just have no way of testing it.