### PR TITLE
Fix client reconnect command on Omada v6+ (Fixes #161)

### DIFF
--- a/custom_components/omada/api/controller.py
+++ b/custom_components/omada/api/controller.py
@@ -170,7 +170,7 @@ class Controller:
     async def _client_request(self, method, end_point, params=None, json=None):
         """Perform a client request using the v6 openapi path when required."""
 
-        if self.version >= "6.0.0":
+        if self.version >= "6.0.0" and not end_point.startswith("/cmd/"):
             return await self._openapi_site_request(method, end_point, params=params, json=json)
 
         return await self._site_request(method, end_point, params=params, json=json)

--- a/custom_components/omada/device_tracker.py
+++ b/custom_components/omada/device_tracker.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, Mapping
 
 from homeassistant.components.device_tracker import DOMAIN
-from homeassistant.components.device_tracker.config_entry import ScannerEntity
+from homeassistant.components.device_tracker import ScannerEntity
 from homeassistant.components.device_tracker.const import SourceType
 from homeassistant.core import callback
 from homeassistant.helpers import device_registry


### PR DESCRIPTION
**Title:** Fix `/cmd/` routing on OpenAPI v2 and deprecated ScannerEntity import

---

**Description:**

This PR fixes two bugs:

**1. Reconnect (and other `/cmd/` actions) fail on Omada Controller v6.0+ with `Unsupported request path`**

In v6.0+, client requests are routed through `/openapi/v2/`, but action commands like `/cmd/clients/.../reconnect` are not supported on that endpoint. `_client_request` in `api/controller.py` now detects `/cmd/` paths and routes them to the standard API endpoint instead.

Fixes #161

**2. Deprecated `ScannerEntity` import**

`ScannerEntity` was imported from `homeassistant.components.device_tracker.config_entry`, which is a deprecated alias being removed in HA Core 2027.6. Updated to import directly from `homeassistant.components.device_tracker`.

Fixes #163

---

**Testing:**
- Verified `/cmd/` endpoints are no longer sent to `/openapi/v2/`
- Confirmed no deprecation warning for `ScannerEntity` on HA Core 2025.x+

Let me try pushing again now that the MCP server has reconnected.